### PR TITLE
Speed up dithering process using Numba JIT.

### DIFF
--- a/output/.gitignore
+++ b/output/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 *.mp4
+*.png

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-opencv-python==4.5.5.62
-numpy==1.22.0
+opencv-python==4.9.0.80
+numpy==1.26.3
+numba==0.58.1


### PR DESCRIPTION
By using Numba JIT on the dithering function, you can drastically speed up the runtime of the program. From my informal testing this speeds the processing per frame from around 0.7 seconds to just a few milliseconds.

I used the basic optimizations found in this code: https://gist.github.com/bzamecnik/33e10b13aae34358c16d1b6c69e89b01